### PR TITLE
Serve previous year question without page reloading

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@
     @file: app.py
     @author: Suraj Kumar Giri
     @init-date: 15th Oct 2022
-    @last-modified: 1st May 2023
+    @last-modified: 2nd May 2023
 
     @description:
         * Module to run the web app and handle all the routes.
@@ -162,47 +162,9 @@ def gallery():
     return render_template('gallery.html', oddNumbers=[odd for odd in range(1, 12) if odd % 2 != 0])
 
 
-@app.route("/previousYearQuestions", methods=["GET", "POST"])
+@app.route("/previousYearQuestions", methods=["GET"])
 def previousYearQuestions():
-    def invalidRequest(errorMessage: str = "Invalid Request") -> Response:
-        """
-            Description:
-                - Function to send send invalid request along with status 400 when called.
-
-            Args:
-                * errorMessage (str, optional):
-                    - Error message to be sent along with status 400 (shown on the web page).
-
-            Returns:
-                * Response:
-                    - Response object with status 400 and error message in response body/content.
-        """
-        content = render_template('previousYearQuestions.html', isSubmitClicked=True,
-                                  databaseResponse=None, errorMessage=errorMessage)
-        return Response(content, status=HTTPStatus.BAD_REQUEST, headers={'Content-Type': 'text/html'})
-
     logging.info("Previous Year Questions page is called...")
-    if request.method == "POST":
-        logging.info(
-            'A post request is received in previousYearQuestions route...')
-        userSelection = request.form
-        print(userSelection)
-
-        # credentials received
-        semester = userSelection.get('semester')
-        source = userSelection.get('source')
-        print("semester: ", semester)
-
-        if validation.isValidSource(source) and validation.isValidSemester(semester):
-            print("All data are valid...")
-            pyqObj = pyqDb.PreviousYearQuestions(**databaseCredentials)
-            databaseResponse: tuple = pyqObj.getLinks(
-                source=source, semester=semester)
-            return render_template('previousYearQuestions.html', isSubmitClicked=True, databaseResponse=databaseResponse, semester=semester)
-        else:
-            print("Invalid data passed...")
-            return invalidRequest()
-
     return render_template('previousYearQuestions.html')
 
 

--- a/app.py
+++ b/app.py
@@ -168,6 +168,48 @@ def previousYearQuestions():
     return render_template('previousYearQuestions.html')
 
 
+# api route to fetch previous year questions
+@app.route('/api/fetch-previous-year-questions', methods=['POST'])
+def fetchPreviousYearQuestions():
+    def invalidRequest(errorMessage: str = "Invalid Request") -> Response:
+        """
+            Description:
+                - Function to send send invalid request along with status 400 when called.
+
+            Args:
+                * errorMessage (str, optional):
+                    - Error message to be sent along with status 400 (shown on the web page).
+
+            Returns:
+                * Response:
+                    - Response object with status 400 and error message in response body/content.
+        """
+        content = render_template('api/previous-year-questions.html', isSubmitClicked=True,
+                                  databaseResponse=None, errorMessage=errorMessage)
+        return Response(content, status=HTTPStatus.BAD_REQUEST, headers={'Content-Type': 'text/html'})
+
+    if request.method == "POST":
+        logging.info(
+            'A post request is received in api of previous year question route...')
+        userSelection = request.json
+        print(userSelection)
+
+        # credentials received
+        semester = userSelection.get('semester')
+        source = userSelection.get('source')
+        print("semester: ", semester)
+
+        if validation.isValidSource(source) and validation.isValidSemester(semester):
+            print("All data are valid...")
+            pyqObj = pyqDb.PreviousYearQuestions(**databaseCredentials)
+            databaseResponse: tuple = pyqObj.getLinks(
+                source=source, semester=semester)
+            return render_template('api/previous-year-questions.html', isSubmitClicked=True, databaseResponse=databaseResponse, semester=semester)
+        else:
+            print("Invalid data passed...")
+            return invalidRequest()
+
+
 @ app.route("/register", methods=["GET", "POST"])
 def register():
     logging.info("Register page is called...")

--- a/static/js/previous-year-questions.js
+++ b/static/js/previous-year-questions.js
@@ -35,3 +35,16 @@ function createAlert() {
     alert.id = 'myAlert';
     return alert;
 }
+
+/** 
+ * @fetching_previous_year_questions_using_API_route
+ * serving previous year questions using AJAX 
+*/
+
+window.addEventListener('load', () => {
+    /*preventing default behavior of the form element which is after submitting the form page will reload and form data sent using url parameters.*/
+    document.getElementsByTagName('form')[0].addEventListener('submit', (event) => {
+        event.preventDefault();
+    })
+    // document.getElementById('submit-button').addEventListener('click', displayPreviousYearQuestions);
+})

--- a/static/js/previous-year-questions.js
+++ b/static/js/previous-year-questions.js
@@ -45,6 +45,31 @@ window.addEventListener('load', () => {
     /*preventing default behavior of the form element which is after submitting the form page will reload and form data sent using url parameters.*/
     document.getElementsByTagName('form')[0].addEventListener('submit', (event) => {
         event.preventDefault();
+        displayPreviousYearQuestions();
     })
     // document.getElementById('submit-button').addEventListener('click', displayPreviousYearQuestions);
+    /** 
+     * Here, I have not added any event listener on submit button. So, default checking after clicking on submit button of form will work as expected.
+     * Means default checking of form will work as expected.
+     * But If I were added event listener on submit button then default checking of form will not work as expected.
+     * Because, custom event listener will be executed first and then default checking of form will be executed.
+     * And due to custom event listener, default checking of form will not work as expected.
+     */
 })
+
+
+function displayPreviousYearQuestions() {
+    const request = new XMLHttpRequest();
+    if (window.location.hostname == '127.0.0.1')
+        request.open('POST', 'http://127.0.0.1:5000/api/fetch-previous-year-questions', async = true);
+    else
+        request.open('POST', 'https://rdsbca.pythonanywhere.com/api/fetch-previous-year-questions', async = true);
+
+    request.setRequestHeader('Content-Type', 'application/json')
+    const obj = { semester: document.getElementById('semester').value, source: document.getElementById('source').value };
+    console.log(obj)
+    request.send(JSON.stringify(obj))
+    request.onload = () => {
+        document.getElementById("previous-year-questions-container").innerHTML = request.responseText
+    }
+}

--- a/static/js/previous-year-questions.js
+++ b/static/js/previous-year-questions.js
@@ -48,7 +48,7 @@ window.addEventListener('load', () => {
         displayPreviousYearQuestions();
     })
     // document.getElementById('submit-button').addEventListener('click', displayPreviousYearQuestions);
-    /** 
+    /**
      * Here, I have not added any event listener on submit button. So, default checking after clicking on submit button of form will work as expected.
      * Means default checking of form will work as expected.
      * But If I were added event listener on submit button then default checking of form will not work as expected.
@@ -59,6 +59,7 @@ window.addEventListener('load', () => {
 
 
 function displayPreviousYearQuestions() {
+    document.getElementById('loading-svg').style.display = 'block';
     const request = new XMLHttpRequest();
     if (window.location.hostname == '127.0.0.1')
         request.open('POST', 'http://127.0.0.1:5000/api/fetch-previous-year-questions', async = true);
@@ -70,6 +71,7 @@ function displayPreviousYearQuestions() {
     console.log(obj)
     request.send(JSON.stringify(obj))
     request.onload = () => {
-        document.getElementById("previous-year-questions-container").innerHTML = request.responseText
+        document.getElementById("previous-year-questions-container").innerHTML = request.responseText;
+        document.getElementById('loading-svg').style.display = 'none';
     }
 }

--- a/templates/api/previous-year-questions.html
+++ b/templates/api/previous-year-questions.html
@@ -1,0 +1,52 @@
+        <!--After POST-->
+        {%if isSubmitClicked%}
+            {%if databaseResponse%}
+                <div class="alert alert-info" role="alert" style="margin-top:2%; padding-top: 0.3%; padding-bottom: 0.3%;">
+                    <strong>PREVIOUS YEAR QUESTIONS OF SEMESTER {{semester}}
+                        {% if semester=='1'%}
+                            <sup style="margin:-4px">st</sup>
+                        {% elif semester=='2'%}
+                            <sup style="margin:-4px">nd</sup>
+                        {% elif semester=='3'%}
+                            <sup style="margin:-4px">rd</sup>
+                        {% else%}
+                            <sup style="margin:-4px">th</sup>
+                        {%endif%}
+                    </strong>
+                </div>
+
+                <table class="table table-bordered border-primary table-striped table-hover table-group-divider table-responsive" style="margin-top: 1%;">
+                    <thead>
+                        <tr>
+                            <th>Sno</th>
+                            <th>Source</th>
+                            <th>Year</th>
+                            <th>Download</th>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                        {%for row in databaseResponse%}
+                            <tr>
+                                <th scope="col">{{loop.index}}</th>
+                                {% for attribute in row%}
+                                    <td>
+                                        {%if loop.index==3%}
+                                            <a href="files/{{attribute}}" target="_blank">
+                                                <button type="button" class="btn btn-primary" style="padding-bottom:0%;"><i class="material-icons icons">download</i></button>
+                                            </a>
+                                        {%else%}
+                                            {{attribute}}
+                                        {%endif%}
+                                    </td>
+                                {%endfor%}
+                            </tr>
+                        {%endfor%}
+                    </tbody>
+                </table>
+            {%else%}
+                <div class="alert alert-danger" role="alert" style="margin-top: 1%; padding: 0.5%">
+                    {{errorMessage|default("Currently Unavailable")}}
+                </div>  
+            {%endif%}  
+        {%endif%}

--- a/templates/previousYearQuestions.html
+++ b/templates/previousYearQuestions.html
@@ -11,7 +11,7 @@
 <div class="main wrapper clearfix data" style="padding-top:0%;margin-top:0%;color:bold black;">
       <p class="text-center fs-2 text fw-bolder">PREVIOUS YEAR QUESTIONS</p>
 
-      <form action="/previousYearQuestions" method="POST">
+      <form>
 
             <!-- semester -->
             <select class="form-select" aria-label="Default select example" name="semester" required style="margin-bottom: 0.8%;">

--- a/templates/previousYearQuestions.html
+++ b/templates/previousYearQuestions.html
@@ -37,7 +37,9 @@
                 <button type="submit" class="btn btn-primary" id="submit-button">Submit</button>
             </div>
         </form>
+        
+        <div id="previous-year-questions-container">
+        </div>
 </div>
-
 
 {%endblock body%}

--- a/templates/previousYearQuestions.html
+++ b/templates/previousYearQuestions.html
@@ -37,60 +37,6 @@
                 <button type="submit" class="btn btn-primary">Submit</button>
             </div>
         </form>
-
-        <!--After POST-->
-        {%if isSubmitClicked%}
-            {%if databaseResponse%}
-                <div class="alert alert-info" role="alert" style="margin-top:2%; padding-top: 0.3%; padding-bottom: 0.3%;">
-                    <strong>PREVIOUS YEAR QUESTIONS OF SEMESTER {{semester}}
-                        {% if semester=='1'%}
-                            <sup style="margin:-4px">st</sup>
-                        {% elif semester=='2'%}
-                            <sup style="margin:-4px">nd</sup>
-                        {% elif semester=='3'%}
-                            <sup style="margin:-4px">rd</sup>
-                        {% else%}
-                            <sup style="margin:-4px">th</sup>
-                        {%endif%}
-                    </strong>
-                </div>
-
-                <table class="table table-bordered border-primary table-striped table-hover table-group-divider table-responsive" style="margin-top: 1%;">
-                    <thead>
-                        <tr>
-                            <th>Sno</th>
-                            <th>Source</th>
-                            <th>Year</th>
-                            <th>Download</th>
-                        </tr>
-                    </thead>
-
-                    <tbody>
-                        {%for row in databaseResponse%}
-                            <tr>
-                                <th scope="col">{{loop.index}}</th>
-                                {% for attribute in row%}
-                                    <td>
-                                        {%if loop.index==3%}
-                                            <a href="files/{{attribute}}" target="_blank">
-                                                <button type="button" class="btn btn-primary" style="padding-bottom:0%;"><i class="material-icons icons">download</i></button>
-                                            </a>
-                                        {%else%}
-                                            {{attribute}}
-                                        {%endif%}
-                                    </td>
-                                {%endfor%}
-                            </tr>
-                        {%endfor%}
-                    </tbody>
-                </table>
-            {%else%}
-                <div class="alert alert-danger" role="alert" style="margin-top: 1%; padding: 0.5%">
-                    {{errorMessage|default("Currently Unavailable")}}
-                </div>  
-            {%endif%}  
-        {%endif%}
-
 </div>
 
 

--- a/templates/previousYearQuestions.html
+++ b/templates/previousYearQuestions.html
@@ -14,7 +14,7 @@
       <form>
 
             <!-- semester -->
-            <select class="form-select" aria-label="Default select example" name="semester" required style="margin-bottom: 0.8%;">
+            <select class="form-select" aria-label="Default select example" name="semester" id="semester" required style="margin-bottom: 0.8%;">
                 <option selected value="">Select Semester</option>
                 <option value="1">1st</option>
                 <option value="2">2nd</option>
@@ -24,7 +24,7 @@
             </select>         
 
             <!-- source -->
-            <select class="form-select" aria-label="Default select example" name="source" required="true">
+            <select class="form-select" aria-label="Default select example" name="source" id="source" required="true">
                 <option selected value="brabu">Select Source</option>
                 <option value="brabu">BRABU Official (Default)</option>
                 <option value="vaishali">Vaishali Institute, Muzaffarpur (Part of BRABU)</option>
@@ -34,7 +34,7 @@
 
             <!-- Submit Button -->
             <div class="col-auto" style="margin-top:1%;">
-                <button type="submit" class="btn btn-primary">Submit</button>
+                <button type="submit" class="btn btn-primary" id="submit-button">Submit</button>
             </div>
         </form>
 </div>

--- a/templates/previousYearQuestions.html
+++ b/templates/previousYearQuestions.html
@@ -38,6 +38,10 @@
             </div>
         </form>
         
+        <center>
+            <img src="{{url_for("static", filename="gif/ball.svg")}}" alt="Loading..." id="loading-svg" style="display:none;">
+        </center>
+        
         <div id="previous-year-questions-container">
         </div>
 </div>


### PR DESCRIPTION
## To serve previous year's questions without reloading the page
* These changes will enhance how to serve users with the previous year's questions. 
* It uses AJAX to send requests to the server to fetch desired previous year questions and serve to the user without reloading the page. 
* It will enhance user experience while browsing.

Signed-off-by: @surajgirioffl 